### PR TITLE
chore(doc): update CODEOWNERS to bf-consulting-infrastructure (CLD-10873)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BishopFox/consulting-infrastructure
+* @BishopFox/bf-consulting-infrastructure


### PR DESCRIPTION
## Summary

- Replaces legacy team `@BishopFox/consulting-infrastructure` with `@BishopFox/bf-consulting-infrastructure` in `.github/CODEOWNERS`
- Part of the org-wide CODEOWNERS standardization tracked under [CLD-10782](https://bf-eng.atlassian.net/browse/CLD-10782); this repo was identified by the scan in [CLD-10787](https://bf-eng.atlassian.net/browse/CLD-10787)

## Why

The legacy `consulting-infrastructure` GitHub team no longer exists, so review routing is silently broken. The `bf-consulting-infrastructure` team is the active replacement.

## Test plan

- [x] Diff is a single change on one line of `.github/CODEOWNERS`
- [ ] Confirm GitHub recognizes the new team as a valid code owner

Ref: [CLD-10873](https://bf-eng.atlassian.net/browse/CLD-10873)

[CLD-10782]: https://bf-eng.atlassian.net/browse/CLD-10782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLD-10787]: https://bf-eng.atlassian.net/browse/CLD-10787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLD-10873]: https://bf-eng.atlassian.net/browse/CLD-10873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ